### PR TITLE
Show chart legends above charts on small screens

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -28,6 +28,18 @@ canvas.chart.short{aspect-ratio:52/16}
 .tests h3{margin:0 0 6px;font-size:14px;color:#cfe0ff}
 .test-pass{color:#6fe9a6;font-weight:700}
 .test-fail{color:#ff7aa2;font-weight:700}
+@media (max-width:600px){
+  .chart-wrap{
+    display:flex;
+    flex-direction:column;
+  }
+  .chart-wrap .legend-panel{
+    position:static;
+    order:-1;
+    margin-bottom:8px;
+    align-self:flex-start;
+  }
+}
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- reposition chart legends above charts on narrow screens using a mobile media query

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896cf95c9d88323b888d0c1c9890530